### PR TITLE
chore(hooks): improve workflow reminder hooks

### DIFF
--- a/.claude/hookify.warn-git-commit.local.md
+++ b/.claude/hookify.warn-git-commit.local.md
@@ -24,7 +24,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 
 - [ ] Issue exists or was created first
 - [ ] Commit references issue: `Ref #123`
-- [ ] On a feature branch (not main)
+- [ ] On a feature branch (**main is protected - cannot push directly**)
 - [ ] Will create PR after push
 
 See: `.claude/rules/workflow.md` and `.claude/rules/common-conventional-commits-and-naming.md`

--- a/.claude/hookify.warn-git-push.local.md
+++ b/.claude/hookify.warn-git-push.local.md
@@ -10,10 +10,14 @@ action: warn
 
 1. **Check CI status:** `gh pr checks <pr-number> --watch`
 
-2. **If CI passes:**
+2. **If ALL CI checks pass:**
    - Squash merge: `gh pr merge <pr-number> --squash --delete-branch`
    - Switch to main: `git checkout main && git pull`
-   - Check CI on main: `gh run list --branch main --limit 1`
+   - **IMPORTANT: Verify ALL CI on main passes:**
+     ```
+     gh run list --branch main --limit 5
+     gh run watch <run-id>  # Watch each workflow
+     ```
 
 3. **If CI fails:**
    - Check logs: `gh run view <run-id> --log-failed`


### PR DESCRIPTION
## Summary

- Add "main is protected" note to commit hook
- Emphasize checking ALL CI on main after merge in push hook

## Test plan

- [x] Hooks are markdown files, no tests needed
- [ ] CI passes

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)