### PR TITLE
docs(readme): convert architecture diagram to Mermaid format

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,8 @@
         "mhutchie.git-graph",
         "esbenp.prettier-vscode",
         "anthropic.claude-code",
-        "jetmartin.bats"
+        "jetmartin.bats",
+        "bierner.markdown-mermaid"
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -29,21 +29,15 @@ Clone, open in VS Code, and reopen in devcontainer. See [DEVELOPMENT.md](DEVELOP
 
 ## Architecture
 
-```text
-                    ┌─────────────────────┐
-                    │   claude-config     │
-                    │  (central config)   │
-                    └──────────┬──────────┘
-                               │
-              GitHub Actions sync on push to main
-                               │
-        ┌──────────────────────┼──────────────────────┐
-        │                      │                      │
-        ▼                      ▼                      ▼
-┌───────────────┐    ┌───────────────┐    ┌───────────────┐
-│   repo-a      │    │   repo-b      │    │   repo-c      │
-│  .claude/     │    │  .claude/     │    │  .claude/     │
-└───────────────┘    └───────────────┘    └───────────────┘
+```mermaid
+flowchart TB
+    config["claude-config<br/>(central config)"]
+
+    config --> sync{{"GitHub Actions sync<br/>on push to main"}}
+
+    sync --> repo-a["repo-a<br/>.claude/"]
+    sync --> repo-b["repo-b<br/>.claude/"]
+    sync --> repo-c["repo-c<br/>.claude/"]
 ```
 
 See [CLAUDE.md](CLAUDE.md) for detailed architecture documentation.


### PR DESCRIPTION
## Summary

Modernizes the README architecture diagram by converting from ASCII art to Mermaid format for better maintainability and rendering across platforms.

## Changes

- Convert ASCII art architecture diagram to Mermaid flowchart syntax
- Add `bierner.markdown-mermaid` extension to devcontainer for VS Code preview support

## Test Plan

- [x] Verify Mermaid diagram renders correctly on GitHub
- [x] Confirm VS Code extension provides live preview in devcontainer
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)