### PR TITLE
fix(agents): prevent issue-workflow from doing implementation work (#37)

### DIFF
--- a/.claude/agents/common-git-workflow.md
+++ b/.claude/agents/common-git-workflow.md
@@ -6,6 +6,17 @@ model: opus
 
 You are a git workflow assistant that enforces Conventional Commits, discovers repo-specific configuration, and manages state awareness for branches and PRs.
 
+## CRITICAL: Git Operations ONLY
+
+**You ONLY handle git operations. You NEVER:**
+
+- Edit, create, or delete files
+- Run tests or linters
+- Implement features or fixes
+- Ask the user what to do
+
+Changes are ALREADY MADE before you're called. Your ONLY job is to commit them, push, and create PRs.
+
 ## Responsibilities
 
 1. **Require issue number** - REFUSE to commit/PR without one

--- a/.claude/agents/common-issue-workflow.md
+++ b/.claude/agents/common-issue-workflow.md
@@ -6,6 +6,17 @@ model: opus
 
 You are a GitHub issue workflow assistant that finds existing issues or creates new ones.
 
+## CRITICAL: Issue Creation ONLY
+
+**You ONLY create or find issues. You NEVER:**
+
+- Delete, edit, or create files
+- Run implementation commands
+- Make code changes
+- Perform the work described in the issue
+
+Your ONLY job is to return an issue number. Implementation is done separately.
+
 ## Responsibilities
 
 1. Search for existing issues matching the description
@@ -74,4 +85,4 @@ Examples:
 
 - Found existing: `Found existing issue: #123 - <title>`
 - Created new: `Created issue: #123 - <title>`
-- **Next:** Implement the work, then use **git-workflow** for #123
+- **Next:** Implement the work, then commit with **git-workflow** for #123

--- a/.claude/hookify.common-block-branch-without-issue.local.md
+++ b/.claude/hookify.common-block-branch-without-issue.local.md
@@ -2,7 +2,7 @@
 name: block-branch-without-issue
 enabled: false
 event: bash
-pattern: git\s+(checkout\s+-b|branch)\s+(?!\S+-\d+(\s|$))\S+
+pattern: git\s+(checkout\s+-b|branch\s+(?!-|--show|--list|--all|-[arlvd]))\s*(?!\S+-\d+(\s|$))\S+
 action: block
 ---
 

--- a/tests/hooks/hookify_test_cases.yaml
+++ b/tests/hooks/hookify_test_cases.yaml
@@ -522,6 +522,11 @@ test_cases:
     command: "git checkout main"
     expect: allow
 
+  - name: "block-branch-without-issue: git branch --show-current allowed"
+    tool: Bash
+    command: "git branch --show-current"
+    expect: allow
+
   # =============================================================================
   # PR Without Issue (block-pr-without-issue)
   # =============================================================================


### PR DESCRIPTION
Closes #37

## Summary

- Add explicit CRITICAL sections to both `issue-workflow` and `git-workflow` agents clarifying their scope boundaries (no file operations, no implementation)
- Fix hookify regex false positive on `git branch --show-current` by excluding flag-style arguments from the branch name pattern
- Add test case for the fixed regex

## Test Plan

- [x] Tests pass locally (hookify test cases updated)
- [ ] Verify `git branch --show-current` no longer triggers block
- [ ] Verify agents still refuse implementation work when invoked

Co-Authored-By: Claude <noreply@anthropic.com>