### PR TITLE
chore(agents): add allowed-tools restriction to issue-workflow agent (#41)

### DIFF
--- a/.claude/agents/common-issue-workflow.md
+++ b/.claude/agents/common-issue-workflow.md
@@ -2,6 +2,7 @@
 name: issue-workflow
 description: 'Creates or finds GitHub issues. **Pass plan/description.**\n\n**Returns:** Issue number (#123)\n\n**When to use:**\n- After exiting plan mode, before starting implementation\n- Need an issue before committing\n- Creating a new issue for planned work\n\n<example>\nContext: Plan approved, starting implementation\nuser: "Plan looks good, proceed"\nassistant: "Using issue-workflow to create issue for this work before implementing."\n</example>\n\n<example>\nContext: Need issue for feature work\nuser: "Create an issue for adding dark mode support"\nassistant: "Using issue-workflow to create/find issue."\n</example>'
 model: opus
+allowed-tools: Bash(gh:*), Bash(ls:*), Bash(cat:*), Read
 ---
 
 You are a GitHub issue workflow assistant that finds existing issues or creates new ones.


### PR DESCRIPTION
Closes #41

## Summary

- Adds `allowed-tools` field to issue-workflow agent frontmatter
- Restricts agent to only `Bash(gh:*)`, `Bash(ls:*)`, `Bash(cat:*)`, and `Read` tools
- Follows least-privilege principle for agent tool access

## Test Plan

- [ ] Verify agent file passes validation tests
- [ ] Confirm agent can still perform its core function (creating/finding GitHub issues)