### PR TITLE
chore(agents): update merge-workflow and review-responder to sonnet model (#57)

### DIFF
--- a/.claude/agents/common-merge-workflow.md
+++ b/.claude/agents/common-merge-workflow.md
@@ -1,7 +1,7 @@
 ---
 name: merge-workflow
 description: 'Safely merges approved PRs. **Requires PR number**.\n\n**Auto-invokes pr-review** if configured (before merge).\n\n**Pre-merge checks:** Approval, CI, conflicts.\n\n**When to use:**\n- PR is approved and ready to merge\n- After review comments addressed\n\n**REFUSES to merge:**\n- Unapproved PRs (if approval required)\n- PRs with failing CI\n- PRs with merge conflicts\n\n<example>\nContext: PR approved, CI passing\nuser: "Merge PR #45"\nassistant: "Using merge-workflow to verify and merge."\n</example>'
-model: opus
+model: sonnet
 allowed-tools: Task, Bash(gh:*), Bash(test:*), Bash(ls:*), Read, Glob
 ---
 

--- a/.claude/agents/common-review-responder.md
+++ b/.claude/agents/common-review-responder.md
@@ -1,7 +1,7 @@
 ---
 name: review-responder
 description: 'Reads PR review comments and posts replies. **Requires PR number**.\n\n**Two modes:**\n1. **Read mode:** Returns comments for main agent to decide\n2. **Reply mode:** Posts replies with decisions from main agent\n\n<example>\nContext: Read comments\nuser: "Read review comments on PR #45"\nassistant: "Using review-responder to fetch comments."\n</example>\n\n<example>\nContext: Post replies\nuser: "Reply to PR #45: comment 123 fix, comment 456 reject (intentional)"\nassistant: "Using review-responder to post replies."\n</example>'
-model: opus
+model: sonnet
 allowed-tools: Bash(gh:*), Read, Glob, Grep
 ---
 

--- a/.devcontainer/package-lock.json
+++ b/.devcontainer/package-lock.json
@@ -7,7 +7,7 @@
       "name": "devcontainer-tools",
       "dependencies": {
         "@aikidosec/safe-chain": "1.4.1",
-        "@anthropic-ai/claude-code": "2.1.2"
+        "@anthropic-ai/claude-code": "2.1.3"
       }
     },
     "node_modules/@aikidosec/safe-chain": {

--- a/.devcontainer/package.json
+++ b/.devcontainer/package.json
@@ -4,6 +4,6 @@
   "description": "Global tools for devcontainer",
   "dependencies": {
     "@aikidosec/safe-chain": "1.4.1",
-    "@anthropic-ai/claude-code": "2.1.2"
+    "@anthropic-ai/claude-code": "2.1.3"
   }
 }


### PR DESCRIPTION
Closes #57

## Summary

- Switch review-responder and merge-workflow agents from opus to sonnet model for cost efficiency
- Bump claude-code devcontainer package from v2.1.2 to v2.1.3

## Test Plan

- [x] Tests pass (`./test.sh`)
- [x] Linting passes (`./lint.sh`)
- [ ] Verify agents still function correctly with sonnet model

---
Generated with Claude Code