### PR TITLE
chore: improve dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,29 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+      time: "06:00"
+      timezone: "Australia/Melbourne"
+    labels:
+      - "dependencies"
+      - "automated"
+    open-pull-requests-limit: 10
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
 
   # GitHub Actions (SHA-pinned)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
+      time: "06:00"
+      timezone: "Australia/Melbourne"
+    labels:
+      - "dependencies"
+      - "automated"
+      - "github-actions"
+    open-pull-requests-limit: 10
     groups:
       actions:
         patterns:
@@ -22,3 +39,14 @@ updates:
     directory: "/.devcontainer"
     schedule:
       interval: daily
+      time: "06:00"
+      timezone: "Australia/Melbourne"
+    labels:
+      - "dependencies"
+      - "automated"
+      - "npm"
+    open-pull-requests-limit: 10
+    groups:
+      npm-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add consistent schedule time (06:00) and timezone (Australia/Melbourne)
- Add labels for better PR organization (dependencies, automated, ecosystem-specific)
- Set open-pull-requests-limit to 10 for all ecosystems
- Add grouping for devcontainers and npm ecosystems to batch updates

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Check dependabot picks up new config on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)