### PR TITLE
fix: ignore VS Code URL in lychee link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -11,6 +11,9 @@ https://www.conventionalcommits.org/.*
 # MCP server URLs use private .lan domains with shell variable substitution
 .*\.lan/.*
 
+# VS Code site returns 403 to automated link checkers
+https://code.visualstudio.com/.*
+
 # GitHub rate-limits unauthenticated requests (429 Too Many Requests)
 https://github.com/.*
 https://raw.githubusercontent.com/.*


### PR DESCRIPTION
## Summary
- Add `https://code.visualstudio.com/.*` to `.lycheeignore` — site returns 403 to automated link checkers

## Test plan
- [ ] Lint passes with `./lint.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)