### PR TITLE
chore: remove GitHub MCP server and tune settings

### DIFF
--- a/.claude/rules/common-github.md
+++ b/.claude/rules/common-github.md
@@ -2,29 +2,9 @@
 
 > **Repository: detect owner/repo from `git remote get-url origin`**
 
-## Tool Priority
+## Tool
 
-1. **GitHub MCP tools** (`mcp__github__*`) — preferred for all operations
-2. **`gh` CLI** — fallback when MCP tools can't do the operation
-
-MCP tools use the GitHub App identity. CLI uses the user's token. Prefer MCP.
-
-## MCP Capabilities
-
-| Operation | MCP Support |
-|-----------|-------------|
-| Read issues | Yes |
-| Create/update issues | Yes |
-| Comment on issues | Yes |
-| Read PRs (metadata, diff, files) | Yes |
-| Create PRs | Yes |
-| Merge PRs | No — use CLI |
-| Review PRs | No — use CLI |
-| Search issues/PRs/code | Yes |
-| Close issues | Yes |
-| PR checks/status | No — use CLI |
-| Raw API calls | No — use CLI |
-| Checkout PR branch | No — use CLI |
+Use the **`gh` CLI** for all GitHub operations (issues, PRs, code search, API calls).
 
 ## Rules
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,8 @@
   "fastMode": false,
   "model": "claude-opus-4-6[1m]",
   "autoUpdatesChannel": "latest",
+  "effortLevel": "xhigh",
+  "viewMode": "verbose",
   "permissions": {
     "defaultMode": "bypassPermissions",
     "allow": [
@@ -98,6 +100,11 @@
       "WebFetch(domain:trivy.dev)"
     ],
     "deny": [
+      "mcp__bravesearch__brave_local_search",
+      "mcp__bravesearch__brave_video_search",
+      "mcp__bravesearch__brave_image_search",
+      "mcp__bravesearch__brave_news_search",
+      "mcp__bravesearch__brave_summarizer",
       "Read(./**/*id_rsa*)",
       "Read(./**/*id_ed25519*)",
       "Read(./**/*id_ecdsa*)",

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,13 +6,6 @@
       "headers": {
         "X-API-KEY": "${BRAVE_SEARCH_MCP_API_KEY}"
       }
-    },
-    "github": {
-      "type": "http",
-      "url": "https://github-mcp.lan.${EXTERNAL_DOMAIN}/mcp",
-      "headers": {
-        "X-API-KEY": "${GITHUB_MCP_API_KEY}"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove GitHub MCP server integration from `.mcp.json` — use `gh` CLI exclusively
- Simplify `common-github.md` rules to reflect `gh` CLI-only approach
- Add `effortLevel` and `viewMode` settings to `settings.json`
- Deny unused Brave search MCP tools (local, video, image, news, summarizer)

## Test plan
- [ ] Verify `gh` CLI operations still work (issues, PRs, search)
- [ ] Confirm denied Brave MCP tools are blocked
- [ ] Run `./test.sh` to validate security rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)