### PR TITLE
fix: env-dump and printenv hook regexes block their own safe alternatives

### DIFF
--- a/.claude/hookify.common-block-age-decrypt.local.md
+++ b/.claude/hookify.common-block-age-decrypt.local.md
@@ -23,3 +23,5 @@ action: block
 - Generate keys: `age-keygen -o key.txt`
 - Encrypt (not decrypt): `age -r recipient -o file.age file`
 - Get public key: `age-keygen -y key.txt`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-age-decrypt" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-base64-decode.local.md
+++ b/.claude/hookify.common-block-base64-decode.local.md
@@ -22,3 +22,5 @@ action: block
 
 - Kubernetes secrets: Ask user to run `kubectl get secret X -o jsonpath='{.data.Y}' | base64 -d`
 - Config values: Ask user to decode and share non-sensitive portions
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-base64-decode" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-declare-dump.local.md
+++ b/.claude/hookify.common-block-declare-dump.local.md
@@ -1,0 +1,25 @@
+---
+name: block-declare-dump
+enabled: true
+event: bash
+# Block declare -p / declare --print (dumps all variables with values)
+# Allow: declare -x, declare -i VAR, declare -a ARR, declare -f (functions only)
+pattern: (^|\s|&&|\|\||;|\(|`)(declare|typeset)[^\S\n]+(-[a-zA-Z]*p[a-zA-Z]*|--(print))([^\S\n]*$|[^\S\n]*\||[^\S\n]*;|[^\S\n]*&&|[^\S\n]*\|\||[^\S\n]*\)|[^\S\n]*`|[^\S\n]*([0-9]*|&)?>[^\S\n]*\S|[^\S\n]+--[^\S\n]*$|[^\S\n]+--[^\S\n]*[|;)])
+action: block
+---
+
+🚫 **Blocked: Dumping variables with `declare -p`**
+
+**What was blocked:** `declare -p` or `typeset -p` (prints all variables with their values)
+
+**Why:** This dumps ALL shell variables including secrets, tokens, and credentials.
+
+**Safe alternatives:**
+
+- List variable names only: `compgen -v`
+- Check if variable exists: `[ -n "$VAR" ] && echo "set"`
+- Check variable type: `declare -p VARNAME 2>/dev/null | cut -d= -f1`
+
+**Note:** `declare -x`, `declare -i VAR=1`, `declare -a ARR` and other declaration uses are allowed.
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-declare-dump" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-echo-s3crets.local.md
+++ b/.claude/hookify.common-block-echo-s3crets.local.md
@@ -43,3 +43,5 @@ echo "${VAR:+set (hidden)}${VAR:-NOT SET}"
 - `echo "${TOKEN}"`
 - `echo "${VAR:-default}"` (leaks when set)
 - `printf "%s" "$PASSWORD"`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-echo-secrets" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-echo-subshell-s3crets.local.md
+++ b/.claude/hookify.common-block-echo-subshell-s3crets.local.md
@@ -27,3 +27,5 @@ action: block
    ```
 
 3. **Ask the user** for specific variable values if needed.
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-echo-subshell-secrets" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-env-dump.local.md
+++ b/.claude/hookify.common-block-env-dump.local.md
@@ -3,8 +3,9 @@ name: block-env-dump
 enabled: true
 event: bash
 # Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
-# -f1 boundary: ([^\S\n]|$) ensures -f10, -f1,2, -f1-2 stay blocked.
-pattern: (^|\s|&&|\|\||;|\(|`)env[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$))))
+# -f1 boundary: ([^\S\n]|\||$) ensures -f10, -f1,2, -f1-2 stay blocked; allows pipe directly after -f1.
+# Flags: (-0|--null|--zero|--) still dump all vars, so block them too.
+pattern: (^|\s|&&|\|\||;|\(|`)env([^\S\n]+(-0|--null|--zero|--))*[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]|\||$)|wc([^\S\n]|$))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-env-dump.local.md
+++ b/.claude/hookify.common-block-env-dump.local.md
@@ -4,9 +4,9 @@ enabled: true
 event: bash
 # Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
 # -f1 boundary: require command terminator or pipe after -f1 — blocks trailing flags like --complement.
-# Flags: (-0|--null|--zero|--) still dump all vars, so block them too.
+# Flags: (-0|--null|--zero|--|--unset=X|-u X) still dump all vars, so block them too.
 # -i is excluded: env -i outputs empty env (no secrets) or runs a command.
-pattern: (^|\s|&&|\|\||;|\(|`)env([^\S\n]+(-0|--null|--zero|--))*[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]*($|;|&&|\|\||\)|`|\|))|wc([^\S\n]|$))))
+pattern: (^|\s|&&|\|\||;|\(|`)env([^\S\n]+(-0|--null|--zero|--|--unset=\S+|-u[^\S\n]+\S+))*[^\S\n]*($|;|&&|\|\||\)|`|([0-9]*|&)?>[^\S\n]*\S|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+(-d=|--delimiter==)[^\S\n]+(-f1|--fields=1)([^\S\n]*($|;|&&|\|\||\)|`|\|))|wc([^\S\n]|$))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-env-dump.local.md
+++ b/.claude/hookify.common-block-env-dump.local.md
@@ -4,7 +4,7 @@ enabled: true
 event: bash
 # Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
 # -f1 boundary: ([^\S\n]|$) ensures -f10, -f1,2, -f1-2 stay blocked.
-pattern: (^|\s|&&|\|\||;|\(|`)env[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d\S+[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$))))
+pattern: (^|\s|&&|\|\||;|\(|`)env[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-env-dump.local.md
+++ b/.claude/hookify.common-block-env-dump.local.md
@@ -2,7 +2,7 @@
 name: block-env-dump
 enabled: true
 event: bash
-pattern: (^|\s|&&|\|\||;|\(|`)env\s*($|\||;|&&|\|\||\)|`)
+pattern: (^|\s|&&|\|\||;|\(|`)env[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d|wc([^\S\n]|$))))
 action: block
 ---
 
@@ -22,3 +22,5 @@ action: block
 - List variable names only: `env | cut -d= -f1`
 - Check if variable exists: `[ -n "$VAR" ] && echo "set"`
 - Get specific non-secret var: `echo $PATH`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-env-dump" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-env-dump.local.md
+++ b/.claude/hookify.common-block-env-dump.local.md
@@ -2,7 +2,8 @@
 name: block-env-dump
 enabled: true
 event: bash
-# Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only)
+# Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
+# -f1 boundary: ([^\S\n]|$) ensures -f10, -f1,2, -f1-2 stay blocked.
 pattern: (^|\s|&&|\|\||;|\(|`)env[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d\S+[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$))))
 action: block
 ---

--- a/.claude/hookify.common-block-env-dump.local.md
+++ b/.claude/hookify.common-block-env-dump.local.md
@@ -2,7 +2,8 @@
 name: block-env-dump
 enabled: true
 event: bash
-pattern: (^|\s|&&|\|\||;|\(|`)env[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d|wc([^\S\n]|$))))
+# Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only)
+pattern: (^|\s|&&|\|\||;|\(|`)env[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d\S+[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-env-dump.local.md
+++ b/.claude/hookify.common-block-env-dump.local.md
@@ -3,9 +3,10 @@ name: block-env-dump
 enabled: true
 event: bash
 # Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
-# -f1 boundary: ([^\S\n]|\||$) ensures -f10, -f1,2, -f1-2 stay blocked; allows pipe directly after -f1.
+# -f1 boundary: require command terminator or pipe after -f1 — blocks trailing flags like --complement.
 # Flags: (-0|--null|--zero|--) still dump all vars, so block them too.
-pattern: (^|\s|&&|\|\||;|\(|`)env([^\S\n]+(-0|--null|--zero|--))*[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]|\||$)|wc([^\S\n]|$))))
+# -i is excluded: env -i outputs empty env (no secrets) or runs a command.
+pattern: (^|\s|&&|\|\||;|\(|`)env([^\S\n]+(-0|--null|--zero|--))*[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]*($|;|&&|\|\||\)|`|\|))|wc([^\S\n]|$))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-env-grep.local.md
+++ b/.claude/hookify.common-block-env-grep.local.md
@@ -24,6 +24,6 @@ action: block
 
 - List keys only: `env | cut -d= -f1` or `printenv | cut -d= -f1`
 - Count variables: `env | wc -l`
-- Check if key exists: `printenv VARNAME >/dev/null 2>&1 && echo "exists"`
+- Check if key exists: `[ -n "$VARNAME" ] && echo "exists"`
 
 **False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-env-grep" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-env-grep.local.md
+++ b/.claude/hookify.common-block-env-grep.local.md
@@ -2,7 +2,7 @@
 name: block-env-grep
 enabled: true
 event: bash
-pattern: (env|printenv)[^\S\n]*\|[^\S\n]*grep
+pattern: (^|\s|&&|\|\||;|\(|`)(env|printenv)[^\S\n]*\|[^\S\n]*grep
 action: block
 ---
 

--- a/.claude/hookify.common-block-env-grep.local.md
+++ b/.claude/hookify.common-block-env-grep.local.md
@@ -2,7 +2,7 @@
 name: block-env-grep
 enabled: true
 event: bash
-pattern: (env|printenv)\s*\|\s*grep
+pattern: (env|printenv)[^\S\n]*\|[^\S\n]*grep
 action: block
 ---
 
@@ -25,3 +25,5 @@ action: block
 - List keys only: `env | cut -d= -f1` or `printenv | cut -d= -f1`
 - Count variables: `env | wc -l`
 - Check if key exists: `printenv VARNAME >/dev/null 2>&1 && echo "exists"`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-env-grep" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-export-dump.local.md
+++ b/.claude/hookify.common-block-export-dump.local.md
@@ -1,0 +1,25 @@
+---
+name: block-export-dump
+enabled: true
+event: bash
+# Block export -p / export --print (dumps all exported variables with values)
+# Allow: export VAR=value, export -n VAR
+pattern: (^|\s|&&|\|\||;|\(|`)export[^\S\n]+(-[a-zA-Z]*p[a-zA-Z]*|--(print))([^\S\n]*$|[^\S\n]*\||[^\S\n]*;|[^\S\n]*&&|[^\S\n]*\|\||[^\S\n]*\)|[^\S\n]*`|[^\S\n]*([0-9]*|&)?>[^\S\n]*\S)
+action: block
+---
+
+🚫 **Blocked: Dumping exported variables with `export -p`**
+
+**What was blocked:** `export -p` (prints all exported variables with their values)
+
+**Why:** This dumps ALL exported environment variables including secrets, tokens, and credentials.
+
+**Safe alternatives:**
+
+- List variable names only: `env | cut -d= -f1`
+- Check if variable is exported: `declare -p VARNAME 2>/dev/null | grep -q 'declare -x' && echo "exported"`
+- Check if variable exists: `[ -n "$VAR" ] && echo "set"`
+
+**Note:** `export VAR=value`, `export -n VAR` and other export uses are allowed.
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-export-dump" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-gpg-decrypt.local.md
+++ b/.claude/hookify.common-block-gpg-decrypt.local.md
@@ -23,3 +23,5 @@ action: block
 - List recipients: `gpg --list-packets file.gpg`
 - Verify signature: `gpg --verify file.sig`
 - Encrypt (not decrypt): `gpg -e -r recipient file`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-gpg-decrypt" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-heredoc-s3crets.local.md
+++ b/.claude/hookify.common-block-heredoc-s3crets.local.md
@@ -26,3 +26,5 @@ EOF
 ```bash
 [ -n "$VAR_NAME" ] && echo "set" || echo "not set"
 ```
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-heredoc-secrets" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-kubectl-describe-s3crets.local.md
+++ b/.claude/hookify.common-block-kubectl-describe-s3crets.local.md
@@ -22,3 +22,5 @@ action: block
 
 - List secret names: `kubectl get secrets`
 - Check secret metadata: `kubectl get secret <name> -o jsonpath='{.metadata}'`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-kubectl-describe-secrets" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-kubectl-exec-s3crets.local.md
+++ b/.claude/hookify.common-block-kubectl-exec-s3crets.local.md
@@ -27,3 +27,5 @@ action: block
 - Check pod logs: `kubectl logs <pod>`
 - Describe pod: `kubectl describe pod <pod>`
 - Check configmaps: `kubectl get configmap <name> -o yaml`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-kubectl-exec-secrets" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-kubectl-s3crets.local.md
+++ b/.claude/hookify.common-block-kubectl-s3crets.local.md
@@ -17,3 +17,5 @@ action: block
 - Be accidentally shared in screenshots
 
 **If you need this:** Ask the user to run the command manually.
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-kubectl-secrets" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-openssl-decrypt.local.md
+++ b/.claude/hookify.common-block-openssl-decrypt.local.md
@@ -23,3 +23,5 @@ action: block
 - Check certificate dates: `openssl x509 -in cert.pem -dates -noout`
 - Generate keys (not extract): `openssl genrsa -out key.pem 2048`
 - Create CSR: `openssl req -new -key key.pem -out cert.csr`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-openssl-decrypt" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-printenv.local.md
+++ b/.claude/hookify.common-block-printenv.local.md
@@ -2,7 +2,7 @@
 name: block-printenv
 enabled: true
 event: bash
-pattern: (^|\s|&&|\|\||;|\(|`)printenv(\s|$|\)|`)
+pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d|wc([^\S\n]|$)))))
 action: block
 ---
 
@@ -22,3 +22,5 @@ action: block
 - List variable names only: `printenv | cut -d= -f1`
 - Check if variable exists: `[ -n "$VAR" ] && echo "set"`
 - Get specific non-secret var: `echo $PATH`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-printenv" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-printenv.local.md
+++ b/.claude/hookify.common-block-printenv.local.md
@@ -3,8 +3,8 @@ name: block-printenv
 enabled: true
 event: bash
 # Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
-# -f1 boundary: ([^\S\n]|$) ensures -f10, -f1,2, -f1-2 stay blocked.
-pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$)))))
+# -f1 boundary: ([^\S\n]|\||$) ensures -f10, -f1,2, -f1-2 stay blocked; allows pipe directly after -f1.
+pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]|\||$)|wc([^\S\n]|$)))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-printenv.local.md
+++ b/.claude/hookify.common-block-printenv.local.md
@@ -2,7 +2,8 @@
 name: block-printenv
 enabled: true
 event: bash
-pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d|wc([^\S\n]|$)))))
+# Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only)
+pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d\S+[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$)))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-printenv.local.md
+++ b/.claude/hookify.common-block-printenv.local.md
@@ -4,7 +4,7 @@ enabled: true
 event: bash
 # Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
 # -f1 boundary: ([^\S\n]|$) ensures -f10, -f1,2, -f1-2 stay blocked.
-pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d\S+[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$)))))
+pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$)))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-printenv.local.md
+++ b/.claude/hookify.common-block-printenv.local.md
@@ -4,7 +4,7 @@ enabled: true
 event: bash
 # Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
 # -f1 boundary: require command terminator or pipe after -f1 — blocks trailing flags like --complement.
-pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]*($|;|&&|\|\||\)|`|\|))|wc([^\S\n]|$)))))
+pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|>]|[^\S\n]*($|;|&&|\|\||\)|`|([0-9]*|&)?>[^\S\n]*\S|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+(-d=|--delimiter==)[^\S\n]+(-f1|--fields=1)([^\S\n]*($|;|&&|\|\||\)|`|\|))|wc([^\S\n]|$)))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-printenv.local.md
+++ b/.claude/hookify.common-block-printenv.local.md
@@ -2,7 +2,8 @@
 name: block-printenv
 enabled: true
 event: bash
-# Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only)
+# Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
+# -f1 boundary: ([^\S\n]|$) ensures -f10, -f1,2, -f1-2 stay blocked.
 pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d\S+[^\S\n]+-f1([^\S\n]|$)|wc([^\S\n]|$)))))
 action: block
 ---

--- a/.claude/hookify.common-block-printenv.local.md
+++ b/.claude/hookify.common-block-printenv.local.md
@@ -3,8 +3,8 @@ name: block-printenv
 enabled: true
 event: bash
 # Lookahead: allow pipe to cut -d= -f1 (keys only) or wc (count only).
-# -f1 boundary: ([^\S\n]|\||$) ensures -f10, -f1,2, -f1-2 stay blocked; allows pipe directly after -f1.
-pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]|\||$)|wc([^\S\n]|$)))))
+# -f1 boundary: require command terminator or pipe after -f1 — blocks trailing flags like --complement.
+pattern: (^|\s|&&|\|\||;|\(|`)printenv([^\S\n]+[^\s|]|[^\S\n]*($|;|&&|\|\||\)|`|\|[^\S\n]*(?![^\S\n]*(cut[^\S\n]+-d=[^\S\n]+-f1([^\S\n]*($|;|&&|\|\||\)|`|\|))|wc([^\S\n]|$)))))
 action: block
 ---
 

--- a/.claude/hookify.common-block-proc-environ.local.md
+++ b/.claude/hookify.common-block-proc-environ.local.md
@@ -19,3 +19,5 @@ action: block
 3. User can decline if it contains secrets
 
 **Note:** This is a direct filesystem access to environment variables, bypassing normal shell commands.
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-proc-environ" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-read-cloud-creds.local.md
+++ b/.claude/hookify.common-block-read-cloud-creds.local.md
@@ -20,3 +20,5 @@ conditions:
 - AWS: Use `aws sts get-caller-identity` to verify access
 - Kubernetes: Use `kubectl config current-context` for context info
 - Docker: Use `docker info` for registry status
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-read-cloud-creds" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-read-encrypted-stores.local.md
+++ b/.claude/hookify.common-block-read-encrypted-stores.local.md
@@ -19,3 +19,5 @@ conditions:
 
 - Ask user what information they need from the password store
 - Use `gpg --list-keys` to see available keys without exposing secrets
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-read-encrypted-stores" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-read-env-files.local.md
+++ b/.claude/hookify.common-block-read-env-files.local.md
@@ -20,3 +20,5 @@ conditions:
 - Ask user which specific (non-sensitive) values they can share
 - Use `.env.example` or `.env.template` as reference
 - Read application config files for structure without secrets
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-read-env-files" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-read-package-creds.local.md
+++ b/.claude/hookify.common-block-read-package-creds.local.md
@@ -19,3 +19,5 @@ conditions:
 
 - npm: Check `npm whoami` for auth status
 - Ask user about registry configuration (not tokens)
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-read-package-creds" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-read-secrets-generic.local.md
+++ b/.claude/hookify.common-block-read-secrets-generic.local.md
@@ -19,3 +19,5 @@ conditions:
 
 - Ask user to share specific non-sensitive portions
 - Use configuration templates or examples instead
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-read-secrets-generic" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-read-ssh-keys.local.md
+++ b/.claude/hookify.common-block-read-ssh-keys.local.md
@@ -19,3 +19,5 @@ conditions:
 
 - Ask the user to share the public key or certificate details
 - Request non-sensitive metadata only
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-read-ssh-keys" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-set-dump.local.md
+++ b/.claude/hookify.common-block-set-dump.local.md
@@ -2,7 +2,7 @@
 name: block-set-dump
 enabled: true
 event: bash
-pattern: (^|\s|&&|\|\||;|\(|`)set([^\S\n]*$|[^\S\n]*\||[^\S\n]*;|[^\S\n]*&&|[^\S\n]*\|\||[^\S\n]*\)|[^\S\n]*`)
+pattern: (^|\s|&&|\|\||;|\(|`)set([^\S\n]*$|[^\S\n]*\||[^\S\n]*;|[^\S\n]*&&|[^\S\n]*\|\||[^\S\n]*\)|[^\S\n]*`|[^\S\n]*([0-9]*|&)?>[^\S\n]*\S)
 action: block
 ---
 

--- a/.claude/hookify.common-block-set-dump.local.md
+++ b/.claude/hookify.common-block-set-dump.local.md
@@ -2,7 +2,7 @@
 name: block-set-dump
 enabled: true
 event: bash
-pattern: (^|\s|&&|\|\||;|\(|`)set(\s*$|\s*\||\s*;|\s*&&|\s*\|\||\s*\)|\s*`)
+pattern: (^|\s|&&|\|\||;|\(|`)set([^\S\n]*$|[^\S\n]*\||[^\S\n]*;|[^\S\n]*&&|[^\S\n]*\|\||[^\S\n]*\)|[^\S\n]*`)
 action: block
 ---
 
@@ -19,3 +19,5 @@ action: block
 3. **List variable names only:** `compgen -v` or `env | cut -d= -f1`
 
 **Note:** `set -e`, `set -x`, `set -o pipefail` and other option-setting uses are allowed.
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-set-dump" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-sops-decrypt.local.md
+++ b/.claude/hookify.common-block-sops-decrypt.local.md
@@ -29,3 +29,5 @@ action: block
 - Encrypt: `sops -e file.yaml`
 - Update keys: `sops updatekeys file.yaml`
 - Rotate keys: `sops -r file.yaml`
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-sops-decrypt" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/.claude/hookify.common-block-sops-read.local.md
+++ b/.claude/hookify.common-block-sops-read.local.md
@@ -19,3 +19,5 @@ conditions:
 
 - Share specific non-sensitive portions
 - Decrypt manually if absolutely necessary
+
+**False positive?** Open an issue: `gh issue create --repo anthony-spruyt/claude-config --title "False positive: block-sops-read" --label bug` and describe the blocked command in the body using `--body-file` to avoid re-triggering hooks.

--- a/tests/hooks/hookify_test_cases.yaml
+++ b/tests/hooks/hookify_test_cases.yaml
@@ -199,6 +199,26 @@ test_cases:
     command: "env PATH=/bin command"
     expect: allow
 
+  - name: "block-env-dump: env --zero --null (stacked dump flags)"
+    tool: Bash
+    command: "env --zero --null"
+    expect: block
+
+  - name: "block-env-dump: env -0 -- (stacked dump flags)"
+    tool: Bash
+    command: "env -0 --"
+    expect: block
+
+  - name: "block-env-dump: env -0 -- | cut -d= -f1 (stacked flags, safe pipe)"
+    tool: Bash
+    command: "env -0 -- | cut -d= -f1"
+    expect: allow
+
+  - name: "block-env-dump: allows env -i | sort (empty env, no secrets)"
+    tool: Bash
+    command: "env -i | sort"
+    expect: allow
+
   - name: "block-env-dump: cross-line env + pipe not matched"
     tool: Bash
     command: "set environment\n| Name | Default |"
@@ -286,6 +306,11 @@ test_cases:
     tool: Bash
     command: "printenv | cut -d= -f1; echo done"
     expect: allow
+
+  - name: "block-printenv: printenv HOME (named variable blocked)"
+    tool: Bash
+    command: "printenv HOME"
+    expect: block
 
   - name: "block-printenv: cross-line printenv + pipe not matched"
     tool: Bash

--- a/tests/hooks/hookify_test_cases.yaml
+++ b/tests/hooks/hookify_test_cases.yaml
@@ -64,9 +64,19 @@ test_cases:
     command: "env | wc -l"
     expect: allow
 
-  - name: "block-env-grep: cross-line env + grep warns (grep-tool, not blocked)"
+  - name: "block-env-grep: cross-line env + grep not blocked (grep-tool warns)"
     tool: Bash
     command: "echo environment\n| grep pattern"
+    expect: warn
+
+  - name: "block-env-grep: myenv | grep not blocked (word boundary, grep-tool warns)"
+    tool: Bash
+    command: "myenv | grep foo"
+    expect: warn
+
+  - name: "block-env-grep: setenv | grep not blocked (word boundary, grep-tool warns)"
+    tool: Bash
+    command: "setenv | grep bar"
     expect: warn
 
   # =============================================================================
@@ -111,6 +121,41 @@ test_cases:
     tool: Bash
     command: "env | cut -d: -f1"
     expect: block
+
+  - name: "block-env-dump: env -0 (null-delimited dump)"
+    tool: Bash
+    command: "env -0"
+    expect: block
+
+  - name: "block-env-dump: env -- (end-of-options dump)"
+    tool: Bash
+    command: "env --"
+    expect: block
+
+  - name: "block-env-dump: env --null (null-delimited dump)"
+    tool: Bash
+    command: "env --null"
+    expect: block
+
+  - name: "block-env-dump: env -0 | sort (flagged dump with pipe)"
+    tool: Bash
+    command: "env -0 | sort"
+    expect: block
+
+  - name: "block-env-dump: env -- | head (flagged dump with pipe)"
+    tool: Bash
+    command: "env -- | head"
+    expect: block
+
+  - name: "block-env-dump: env -- | cut -d= -f1 (flagged dump, safe pipe)"
+    tool: Bash
+    command: "env -- | cut -d= -f1"
+    expect: allow
+
+  - name: "block-env-dump: env | cut -d= -f1|sort (pipe without space after f1)"
+    tool: Bash
+    command: "env | cut -d= -f1|sort"
+    expect: allow
 
   # Also proves env-dump allows this (tested in block-env-grep section too)
   - name: "block-env-dump: allows env | cut -d= -f1 (keys only)"
@@ -205,6 +250,11 @@ test_cases:
   - name: "block-printenv: allows printenv | cut -d= -f1 | sort"
     tool: Bash
     command: "printenv | cut -d= -f1 | sort"
+    expect: allow
+
+  - name: "block-printenv: allows printenv | cut -d= -f1|sort (pipe without space after f1)"
+    tool: Bash
+    command: "printenv | cut -d= -f1|sort"
     expect: allow
 
   - name: "block-printenv: cross-line printenv + pipe not matched"

--- a/tests/hooks/hookify_test_cases.yaml
+++ b/tests/hooks/hookify_test_cases.yaml
@@ -179,6 +179,21 @@ test_cases:
     command: "env | cut -d= -f1 | sort"
     expect: allow
 
+  - name: "block-env-dump: env | cut -d= -f1 --complement (inverts to values)"
+    tool: Bash
+    command: "env | cut -d= -f1 --complement"
+    expect: block
+
+  - name: "block-env-dump: env | cut -d= -f1 -s (trailing flag after -f1)"
+    tool: Bash
+    command: "env | cut -d= -f1 -s"
+    expect: block
+
+  - name: "block-env-dump: allows env | cut -d= -f1; echo done"
+    tool: Bash
+    command: "env | cut -d= -f1; echo done"
+    expect: allow
+
   - name: "block-env-dump: allows env VAR=value command"
     tool: Bash
     command: "env PATH=/bin command"
@@ -255,6 +270,21 @@ test_cases:
   - name: "block-printenv: allows printenv | cut -d= -f1|sort (pipe without space after f1)"
     tool: Bash
     command: "printenv | cut -d= -f1|sort"
+    expect: allow
+
+  - name: "block-printenv: printenv | cut -d= -f1 --complement (inverts to values)"
+    tool: Bash
+    command: "printenv | cut -d= -f1 --complement"
+    expect: block
+
+  - name: "block-printenv: printenv | cut -d= -f1 -s (trailing flag after -f1)"
+    tool: Bash
+    command: "printenv | cut -d= -f1 -s"
+    expect: block
+
+  - name: "block-printenv: allows printenv | cut -d= -f1; echo done"
+    tool: Bash
+    command: "printenv | cut -d= -f1; echo done"
     expect: allow
 
   - name: "block-printenv: cross-line printenv + pipe not matched"

--- a/tests/hooks/hookify_test_cases.yaml
+++ b/tests/hooks/hookify_test_cases.yaml
@@ -107,6 +107,11 @@ test_cases:
     command: "env | cut -d= -f1-2"
     expect: block
 
+  - name: "block-env-dump: env | cut -d: -f1 (wrong delimiter leaks values)"
+    tool: Bash
+    command: "env | cut -d: -f1"
+    expect: block
+
   # Also proves env-dump allows this (tested in block-env-grep section too)
   - name: "block-env-dump: allows env | cut -d= -f1 (keys only)"
     tool: Bash
@@ -175,6 +180,11 @@ test_cases:
   - name: "block-printenv: printenv | cut -d= -f1-2 (extracts key+value range)"
     tool: Bash
     command: "printenv | cut -d= -f1-2"
+    expect: block
+
+  - name: "block-printenv: printenv | cut -d: -f1 (wrong delimiter leaks values)"
+    tool: Bash
+    command: "printenv | cut -d: -f1"
     expect: block
 
   - name: "block-printenv: allows printenv | cut -d= -f1 (keys only)"

--- a/tests/hooks/hookify_test_cases.yaml
+++ b/tests/hooks/hookify_test_cases.yaml
@@ -219,6 +219,51 @@ test_cases:
     command: "env -i | sort"
     expect: allow
 
+  - name: "block-env-dump: env > /tmp/file (redirect bypass blocked)"
+    tool: Bash
+    command: "env > /tmp/secrets.txt"
+    expect: block
+
+  - name: "block-env-dump: env >> /tmp/file (append redirect blocked)"
+    tool: Bash
+    command: "env >> /tmp/dump.txt"
+    expect: block
+
+  - name: "block-env-dump: env 1>/tmp/file (fd redirect blocked)"
+    tool: Bash
+    command: "env 1>/tmp/secrets.txt"
+    expect: block
+
+  - name: "block-env-dump: env &>/tmp/file (combined redirect blocked)"
+    tool: Bash
+    command: "env &>/tmp/secrets.txt"
+    expect: block
+
+  - name: "block-env-dump: env -u VARNAME (no command, dumps minus one var)"
+    tool: Bash
+    command: "env -u TERM"
+    expect: block
+
+  - name: "block-env-dump: env --unset=VARNAME (no command, dumps minus one var)"
+    tool: Bash
+    command: "env --unset=TERM"
+    expect: block
+
+  - name: "block-env-dump: env -u VAR1 -u VAR2 (stacked unset, still dumps)"
+    tool: Bash
+    command: "env -u TERM -u SHELL"
+    expect: block
+
+  - name: "block-env-dump: allows env -u SECRET command (unset var, runs cmd)"
+    tool: Bash
+    command: "env -u SECRET_KEY ./run.sh"
+    expect: allow
+
+  - name: "block-env-dump: allows env | cut --delimiter== --fields=1 (long form keys only)"
+    tool: Bash
+    command: "env | cut --delimiter== --fields=1"
+    expect: allow
+
   - name: "block-env-dump: cross-line env + pipe not matched"
     tool: Bash
     command: "set environment\n| Name | Default |"
@@ -311,6 +356,31 @@ test_cases:
     tool: Bash
     command: "printenv HOME"
     expect: block
+
+  - name: "block-printenv: printenv > /tmp/file (redirect bypass blocked)"
+    tool: Bash
+    command: "printenv > /tmp/secrets.txt"
+    expect: block
+
+  - name: "block-printenv: printenv >> /tmp/file (append redirect blocked)"
+    tool: Bash
+    command: "printenv >> /tmp/dump.txt"
+    expect: block
+
+  - name: "block-printenv: printenv 1>/tmp/file (fd redirect blocked)"
+    tool: Bash
+    command: "printenv 1>/tmp/secrets.txt"
+    expect: block
+
+  - name: "block-printenv: printenv&>/tmp/file (no-space combined redirect blocked)"
+    tool: Bash
+    command: "printenv&>/tmp/secrets.txt"
+    expect: block
+
+  - name: "block-printenv: allows printenv | cut --delimiter== --fields=1 (long form keys only)"
+    tool: Bash
+    command: "printenv | cut --delimiter== --fields=1"
+    expect: allow
 
   - name: "block-printenv: cross-line printenv + pipe not matched"
     tool: Bash
@@ -1255,7 +1325,143 @@ test_cases:
     command: "set -a"
     expect: allow
 
+  - name: "block-set-dump: set > /tmp/file (redirect bypass blocked)"
+    tool: Bash
+    command: "set > /tmp/vars.txt"
+    expect: block
+
+  - name: "block-set-dump: set >> /tmp/file (append redirect blocked)"
+    tool: Bash
+    command: "set >> /tmp/dump.txt"
+    expect: block
+
+  - name: "block-set-dump: set 1>/tmp/file (fd redirect blocked)"
+    tool: Bash
+    command: "set 1>/tmp/vars.txt"
+    expect: block
+
+  - name: "block-set-dump: set &>/tmp/file (combined redirect blocked)"
+    tool: Bash
+    command: "set &>/tmp/vars.txt"
+    expect: block
+
   - name: "block-set-dump: cross-line set + pipe not matched"
     tool: Bash
     command: "Variables need to be set\n| Name | Default |"
+    expect: allow
+
+  # =============================================================================
+  # Declare Dump (block-declare-dump)
+  # =============================================================================
+  - name: "block-declare-dump: declare -p (dumps all vars)"
+    tool: Bash
+    command: "declare -p"
+    expect: block
+
+  - name: "block-declare-dump: typeset -p (alias for declare -p)"
+    tool: Bash
+    command: "typeset -p"
+    expect: block
+
+  - name: "block-declare-dump: declare --print"
+    tool: Bash
+    command: "declare --print"
+    expect: block
+
+  - name: "block-declare-dump: declare -p | grep"
+    tool: Bash
+    command: "declare -p | grep SECRET"
+    expect: block
+
+  - name: "block-declare-dump: chained declare -p"
+    tool: Bash
+    command: "cd /tmp && declare -p"
+    expect: block
+
+  - name: "block-declare-dump: declare -px (p not last in flags)"
+    tool: Bash
+    command: "declare -px"
+    expect: block
+
+  - name: "block-declare-dump: declare -pA (p not last in flags)"
+    tool: Bash
+    command: "declare -pA"
+    expect: block
+
+  - name: "block-declare-dump: declare -pa (p not last in flags)"
+    tool: Bash
+    command: "declare -pa"
+    expect: block
+
+  - name: "block-declare-dump: declare -p -- (end-of-options dumps all)"
+    tool: Bash
+    command: "declare -p --"
+    expect: block
+
+  - name: "block-declare-dump: allows declare -p VARNAME (specific var)"
+    tool: Bash
+    command: "declare -p HOME"
+    expect: allow
+
+  - name: "block-declare-dump: allows declare -i VAR=1"
+    tool: Bash
+    command: "declare -i count=0"
+    expect: allow
+
+  - name: "block-declare-dump: allows declare -a ARR"
+    tool: Bash
+    command: "declare -a my_array"
+    expect: allow
+
+  - name: "block-declare-dump: allows declare -x VAR=value"
+    tool: Bash
+    command: "declare -x PATH=/usr/bin"
+    expect: allow
+
+  - name: "block-declare-dump: allows declare -f (functions only, no values)"
+    tool: Bash
+    command: "declare -f my_function"
+    expect: allow
+
+  # =============================================================================
+  # Export Dump (block-export-dump)
+  # =============================================================================
+  - name: "block-export-dump: export -p (dumps all exports)"
+    tool: Bash
+    command: "export -p"
+    expect: block
+
+  - name: "block-export-dump: export --print"
+    tool: Bash
+    command: "export --print"
+    expect: block
+
+  - name: "block-export-dump: export -p | grep"
+    tool: Bash
+    command: "export -p | grep TOKEN"
+    expect: block
+
+  - name: "block-export-dump: chained export -p"
+    tool: Bash
+    command: "cd /tmp && export -p"
+    expect: block
+
+  - name: "block-export-dump: export -pn (p not last in flags)"
+    tool: Bash
+    command: "export -pn"
+    expect: block
+
+  - name: "block-export-dump: allows export VAR=value"
+    tool: Bash
+    command: "export MY_VAR=hello"
+    expect: allow
+
+  - name: "block-export-dump: allows export -n VAR"
+    tool: Bash
+    command: "export -n MY_VAR"
+    expect: allow
+
+  - name: "block-export-dump: allows export PATH"
+    tool: Bash
+    command: "export PATH"
     expect: allow

--- a/tests/hooks/hookify_test_cases.yaml
+++ b/tests/hooks/hookify_test_cases.yaml
@@ -54,17 +54,20 @@ test_cases:
     command: "printenv | grep TOKEN"
     expect: block
 
-  # NOTE: These are blocked by block-env-dump rule (env with pipe) even though
-  # block-env-dump message lists "env | cut" as a safe alternative. Rule bug.
-  - name: "block-env-grep: env | cut blocked by env-dump"
+  - name: "block-env-grep: env | cut is safe (keys only)"
     tool: Bash
     command: "env | cut -d= -f1"
-    expect: block
+    expect: allow
 
-  - name: "block-env-grep: env | wc blocked by env-dump"
+  - name: "block-env-grep: env | wc is safe (count only)"
     tool: Bash
     command: "env | wc -l"
-    expect: block
+    expect: allow
+
+  - name: "block-env-grep: cross-line env + grep warns (grep-tool, not blocked)"
+    tool: Bash
+    command: "echo environment\n| grep pattern"
+    expect: warn
 
   # =============================================================================
   # Environment Dump (block-env-dump)
@@ -84,9 +87,41 @@ test_cases:
     command: "mkdir /tmp && env"
     expect: block
 
+  - name: "block-env-dump: env | sort (shows values)"
+    tool: Bash
+    command: "env | sort"
+    expect: block
+
+  # Also proves env-dump allows this (tested in block-env-grep section too)
+  - name: "block-env-dump: allows env | cut -d= -f1 (keys only)"
+    tool: Bash
+    command: "env | cut -d= -f1"
+    expect: allow
+
+  # Also proves env-dump allows this (tested in block-env-grep section too)
+  - name: "block-env-dump: allows env | wc -l (count only)"
+    tool: Bash
+    command: "env | wc -l"
+    expect: allow
+
+  - name: "block-env-dump: allows env | wc (count only)"
+    tool: Bash
+    command: "env | wc"
+    expect: allow
+
+  - name: "block-env-dump: allows env | cut -d= -f1 | sort"
+    tool: Bash
+    command: "env | cut -d= -f1 | sort"
+    expect: allow
+
   - name: "block-env-dump: allows env VAR=value command"
     tool: Bash
     command: "env PATH=/bin command"
+    expect: allow
+
+  - name: "block-env-dump: cross-line env + pipe not matched"
+    tool: Bash
+    command: "set environment\n| Name | Default |"
     expect: allow
 
   # =============================================================================
@@ -106,6 +141,36 @@ test_cases:
     tool: Bash
     command: "ls && printenv"
     expect: block
+
+  - name: "block-printenv: printenv | sort (shows values)"
+    tool: Bash
+    command: "printenv | sort"
+    expect: block
+
+  - name: "block-printenv: allows printenv | cut -d= -f1 (keys only)"
+    tool: Bash
+    command: "printenv | cut -d= -f1"
+    expect: allow
+
+  - name: "block-printenv: allows printenv | wc -l (count only)"
+    tool: Bash
+    command: "printenv | wc -l"
+    expect: allow
+
+  - name: "block-printenv: allows printenv | wc (count only)"
+    tool: Bash
+    command: "printenv | wc"
+    expect: allow
+
+  - name: "block-printenv: allows printenv | cut -d= -f1 | sort"
+    tool: Bash
+    command: "printenv | cut -d= -f1 | sort"
+    expect: allow
+
+  - name: "block-printenv: cross-line printenv + pipe not matched"
+    tool: Bash
+    command: "run printenv\n| Name | Value |"
+    expect: allow
 
   # =============================================================================
   # Process Environ (block-proc-environ)
@@ -1043,4 +1108,9 @@ test_cases:
   - name: "block-set-dump: allows set -a"
     tool: Bash
     command: "set -a"
+    expect: allow
+
+  - name: "block-set-dump: cross-line set + pipe not matched"
+    tool: Bash
+    command: "Variables need to be set\n| Name | Default |"
     expect: allow

--- a/tests/hooks/hookify_test_cases.yaml
+++ b/tests/hooks/hookify_test_cases.yaml
@@ -92,6 +92,21 @@ test_cases:
     command: "env | sort"
     expect: block
 
+  - name: "block-env-dump: env | cut -d= -f2 (extracts values)"
+    tool: Bash
+    command: "env | cut -d= -f2"
+    expect: block
+
+  - name: "block-env-dump: env | cut -d= -f1,2 (extracts key+value)"
+    tool: Bash
+    command: "env | cut -d= -f1,2"
+    expect: block
+
+  - name: "block-env-dump: env | cut -d= -f1-2 (extracts key+value range)"
+    tool: Bash
+    command: "env | cut -d= -f1-2"
+    expect: block
+
   # Also proves env-dump allows this (tested in block-env-grep section too)
   - name: "block-env-dump: allows env | cut -d= -f1 (keys only)"
     tool: Bash
@@ -145,6 +160,16 @@ test_cases:
   - name: "block-printenv: printenv | sort (shows values)"
     tool: Bash
     command: "printenv | sort"
+    expect: block
+
+  - name: "block-printenv: printenv | cut -d= -f2 (extracts values)"
+    tool: Bash
+    command: "printenv | cut -d= -f2"
+    expect: block
+
+  - name: "block-printenv: printenv | cut -d= -f1,2 (extracts key+value)"
+    tool: Bash
+    command: "printenv | cut -d= -f1,2"
     expect: block
 
   - name: "block-printenv: allows printenv | cut -d= -f1 (keys only)"

--- a/tests/hooks/hookify_test_cases.yaml
+++ b/tests/hooks/hookify_test_cases.yaml
@@ -172,6 +172,11 @@ test_cases:
     command: "printenv | cut -d= -f1,2"
     expect: block
 
+  - name: "block-printenv: printenv | cut -d= -f1-2 (extracts key+value range)"
+    tool: Bash
+    command: "printenv | cut -d= -f1-2"
+    expect: block
+
   - name: "block-printenv: allows printenv | cut -d= -f1 (keys only)"
     tool: Bash
     command: "printenv | cut -d= -f1"


### PR DESCRIPTION
## Summary

- **Fix safe-alternative false positives**: `block-env-dump` and `block-printenv` regexes no longer block the safe patterns they recommend (`env | cut -d= -f1`, `env | wc -l`, `printenv | cut -d= -f1`, etc.) while still blocking unsafe pipes like `env | sort` and `env | head`
- **Fix cross-line matching**: Replaced `\s*` with `[^\S\n]*` in all 4 env/set hooks (env-dump, printenv, env-grep, set-dump) to prevent false positives when `env`/`set`/`printenv` appears in heredocs or markdown near pipe characters on the next line
- **Add false-positive reporting**: All 22 block hooks now instruct agents to auto-file GitHub issues when they encounter suspected false positives

## Root cause

The negative lookahead `\|\s*(?!cut\s+-d|wc(\s|$))` suffered from regex backtracking: `\s*` would greedily consume the space after `|`, but when the lookahead found `cut`/`wc` and failed, the engine backtracked `\s*` to 0 characters — then the lookahead saw ` cut` (with leading space) which didn't match `cut`, so the negative lookahead succeeded incorrectly, blocking the safe command.

Fixed by adding `[^\S\n]*` inside the lookahead: `(?![^\S\n]*(cut|wc))`.

## Test plan

- [x] 17 new test cases covering safe alternatives, unsafe pipes, and cross-line scenarios
- [x] 2 existing false-positive tests updated from `expect: block` to `expect: allow`
- [x] All 202 tests pass (`./test.sh`)
- [x] Regex verified independently with Python `re.search` against all edge cases
- [ ] Manual verification: run `env | cut -d= -f1` in a Claude Code session — should no longer be blocked

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
