### PR TITLE
chore: set agentmemory SAFE_CHAIN_LOGGING to silent

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,8 @@
       "args": ["-y", "@agentmemory/mcp"],
       "env": {
         "AGENTMEMORY_URL": "${AGENTMEMORY_URL}",
-        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET}"
+        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET}",
+        "SAFE_CHAIN_LOGGING": "silent"
       }
     },
     "bravesearch": {


### PR DESCRIPTION
## Summary
- Add `SAFE_CHAIN_LOGGING=silent` env var to agentmemory MCP server config
- Suppresses verbose chain logging output from the agentmemory service

## Test plan
- [ ] Verify agentmemory MCP server starts without errors
- [ ] Confirm chain logging is suppressed in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)