### PR TITLE
feat(hooks): add common warn rule for Trivy SARIF alert queries

### DIFF
--- a/.claude/hookify.common-warn-trivy-sarif.local.md
+++ b/.claude/hookify.common-warn-trivy-sarif.local.md
@@ -1,0 +1,15 @@
+---
+name: warn-trivy-sarif
+enabled: true
+event: bash
+pattern: gh\s+run\s+view.*--log.*CVE|gh\s+run\s+view.*--log.*trivy|--log.*grep.*CVE|--log.*grep.*trivy
+action: warn
+warn_once: true
+---
+
+**[warn-trivy-sarif]**
+Trivy SARIF alerts live under `refs/pull/N/merge`, not source branch. Use the API instead of parsing logs:
+
+```
+gh api "repos/OWNER/REPO/code-scanning/alerts?ref=refs/pull/PR_NUMBER/merge&per_page=100" --jq '[.[] | select(.rule.security_severity_level == "critical" or .rule.security_severity_level == "high") | {number, rule: .rule.id, severity: .rule.security_severity_level, state: .state}]'
+```


### PR DESCRIPTION
## Summary

- Add `hookify.common-warn-trivy-sarif.local.md` to all repos via claude-config sync
- Fires once per session when Claude tries to grep CI logs for CVEs/Trivy results
- Reminds to use `gh api` with `refs/pull/N/merge` ref instead of parsing logs
- Verified on container-images PR #664 — the API query works, commit SHA query does not

## Test plan

- [x] Pattern tested against real commands from container-images CVE debugging session
- [x] API query verified returns correct alerts for PR #664
- [ ] Sync to a target repo and confirm hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)