### PR TITLE
feat(hookify): add warn-code-scanning-ref guard

### DIFF
--- a/.claude/hookify.common-warn-code-scanning-ref.local.md
+++ b/.claude/hookify.common-warn-code-scanning-ref.local.md
@@ -2,7 +2,7 @@
 name: warn-code-scanning-ref
 enabled: true
 event: bash
-pattern: gh\s+api\s+.*code-scanning/alerts(?!.*refs/pull/)
+pattern: (?:^|[;&|]\s*)gh\s+api\s+[^"]*code-scanning/alerts(?!.*refs/pull/)
 action: warn
 warn_once: true
 ---

--- a/.claude/hookify.common-warn-code-scanning-ref.local.md
+++ b/.claude/hookify.common-warn-code-scanning-ref.local.md
@@ -1,0 +1,16 @@
+---
+name: warn-code-scanning-ref
+enabled: true
+event: bash
+pattern: gh\s+api\s+.*code-scanning/alerts(?!.*refs/pull/)
+action: warn
+warn_once: true
+---
+
+**[warn-code-scanning-ref]**
+Code-scanning SARIF alerts are indexed under the merge ref, not the source branch. Without `ref=refs/pull/N/merge`, the API returns 404.
+
+Correct usage:
+```
+gh api "repos/OWNER/REPO/code-scanning/alerts?ref=refs/pull/PR_NUMBER/merge&per_page=100" --jq '[.[] | select(.rule.security_severity_level == "critical" or .rule.security_severity_level == "high") | {number, rule: .rule.id, severity: .rule.security_severity_level, state: .state}]'
+```


### PR DESCRIPTION
## Summary
- Add hookify guard that warns when `gh api code-scanning/alerts` is called without `refs/pull/N/merge` ref parameter
- Agents get 404 without the merge ref and hallucinate token permission issues
- Complements existing `warn-trivy-sarif` hook (covers CI log parsing path)

## Linked Issue
N/A — discovered via agent telemetry analysis in spruyt-labs

## Changes
- New `.claude/hookify.common-warn-code-scanning-ref.local.md`

## Testing
Pattern tested with grep -P:
- `gh api .../code-scanning/alerts -f state=open` → MATCH (warns)
- `gh api ".../code-scanning/alerts?ref=refs/pull/1475/merge"` → NO MATCH (correct usage passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)