### PR TITLE
docs: mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,20 @@
-# Claude Config
+# claude-config (ARCHIVED)
 
-![CI](https://github.com/anthony-spruyt/claude-config/actions/workflows/ci.yaml/badge.svg) ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
+> **This repository has been archived.** Its content has been migrated to:
+>
+> - **Hookify rules** → [claude-plugins](https://github.com/anthony-spruyt/claude-plugins) (hookify-plus + security-hooks + best-practices plugins)
+> - **Settings + rules distribution** → [repo-operator](https://github.com/anthony-spruyt/repo-operator) (xfg `claude` group)
+> - **Infrastructure rules** → [spruyt-labs](https://github.com/anthony-spruyt/spruyt-labs) (`.claude/hookify-plus/`)
 
-Centralized Claude Code configuration with security-focused distribution across repositories.
+## Migration Guide
 
-## Features
+### For users of this repo's sync
 
-- **Defense-in-depth security** - File permissions, command blocking, and hookify rules
-- **Hub-and-spoke distribution** - Central config synced to all target repositories
-- **Automated sync** - GitHub Actions workflow triggers on config changes
-- **Standardized environment** - Devcontainer with pre-configured tools
-- **Comprehensive testing** - bats-core tests validate all security controls
+1. Remove the GitHub App from your repos (if still installed)
+1. Install plugins: `/plugin marketplace add anthony-spruyt/claude-plugins`
+1. Enable: `hookify-plus`, `security-hooks`, `best-practices`
+1. Old `hookify.*.local.md` files in `.claude/` can be deleted — the new engine ignores them
 
-## Quick Start
+### For repo-operator managed repos
 
-### For Target Repositories
-
-Install the GitHub App to receive config updates:
-
-[Install Claude Config Sync](https://github.com/apps/claude-config-sync)
-
-#### Opting Out of Specific Config
-
-Target repos can exclude specific categories or files by adding `.claude/.sync-config.yaml`:
-
-```yaml
-# Opt out of entire categories
-exclude_categories:
-  - commands
-  - agents
-
-# Opt out of specific files (basename match)
-exclude_files:
-  - "hookify.common-block-kubectl-describe-secrets.local.md"
-  - "common-tdd.md"
-```
-
-**Available categories:** `settings`, `hookify`, `agents`, `rules`, `hooks`, `lib`, `commands`
-
-### For Development
-
-Clone, open in VS Code, and reopen in devcontainer. See [DEVELOPMENT.md](DEVELOPMENT.md) for detailed setup.
-
-## Architecture
-
-```mermaid
-flowchart TB
-    config["claude-config<br/>(central config)"]
-
-    config --> sync{{"GitHub Actions sync<br/>on push to main"}}
-
-    sync --> repo-a["repo-a<br/>.claude/"]
-    sync --> repo-b["repo-b<br/>.claude/"]
-    sync --> repo-c["repo-c<br/>.claude/"]
-```
-
-See [CLAUDE.md](CLAUDE.md) for detailed architecture documentation.
-
-## Security Layers
-
-This repository implements defense-in-depth with three security layers:
-
-1. **File Permissions** - Blocks access to SSH keys, certificates, credentials, and secrets
-1. **Command Blocking** - Prevents commands that could expose secrets (base64, sops, printenv)
-1. **Hookify Rules** - Event-based safety controls for Kubernetes, SOPS, and environment access
-
-**Important:** Claude Code uses different pattern syntaxes:
-
-- **Permissions** (`settings.json`) use **[gitignore patterns](https://git-scm.com/docs/gitignore)** - `*` excludes `/`, use `**` for recursive
-- **Hookify rules** use **Python/PCRE regex** - standard regex syntax with `\s`, `.*`, etc.
-
-See [CLAUDE.md](CLAUDE.md) for detailed pattern matching reference and common mistakes.
-
-## Usage
-
-```bash
-# Manually trigger sync to all repos
-gh workflow run "Sync to Target Repos"
-
-# Sync to specific repos only
-gh workflow run "Sync to Target Repos" -f target_repos="owner/repo"
-
-# Run tests and linter
-./test.sh
-./lint.sh
-```
-
-## Documentation
-
-- [CLAUDE.md](CLAUDE.md) - Detailed architecture, security layers, and development guide
-- [DEVELOPMENT.md](DEVELOPMENT.md) - Devcontainer setup, SSH agent, and tooling
-- [.n8n/README.md](.n8n/README.md) - Webhook automation setup with n8n
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute.
-
-## License
-
-[MIT](LICENSE)
+Settings and rules are now delivered via the `claude` xfg group. No action needed — next sync cycle handles it.


### PR DESCRIPTION
## Summary

- Update README to redirect users to migration targets (claude-plugins, repo-operator, spruyt-labs)
- Include migration guide for users of this repo's sync and repo-operator managed repos

## Context

Content has been migrated:
- Hookify rules → claude-plugins (security-hooks + best-practices plugins)
- Settings + rules distribution → repo-operator (xfg claude group)
- Infrastructure rules → spruyt-labs (.claude/hookify-plus/)

After merge, this repo should be archived via `gh repo archive`.

## Test plan

- [ ] Verify all migration targets have the content
- [ ] Archive repo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)